### PR TITLE
Update generate_datasets.R

### DIFF
--- a/datasets/generate_datasets.R
+++ b/datasets/generate_datasets.R
@@ -4,6 +4,12 @@ setwd(dirname(rstudioapi::getActiveDocumentContext()$path))
 ################################################################################
 ################################################################################
 
+# Create directories "complexity_1", ..., "complexity_5" to organise datasets.
+for (i in c(1:5)) {
+  directory <- paste0("complexity_", i, "/")
+  dir.create(file.path(directory), showWarnings = FALSE)
+}
+
 datasets <- list()
 
 # Scenario 1 - simple, homogeneous claims experience, with zero inflation
@@ -100,10 +106,11 @@ if (packageVersion("SynthETIC") >= "1.1.0") {
 
   # Save as csv files
   for (i in c(1:5)) {
-      dataset <- datasets_cov[[i]]
-      directory <- paste0("complexity_", i, "/")
-      write.csv(dataset$claim_dataset, paste0(directory, "claim_", i, "_cov.csv"))
-      write.csv(dataset$payment_dataset, paste0(directory, "payment_", i, "_cov.csv"))
-      write.csv(dataset$incurred_dataset, paste0(directory, "incurred_", i, "_cov.csv"))
+    dataset <- datasets_cov[[i]]
+    directory <- paste0("complexity_", i, "/")
+    write.csv(dataset$claim_dataset, paste0(directory, "claim_", i, "_cov.csv"))
+    write.csv(dataset$payment_dataset, paste0(directory, "payment_", i, "_cov.csv"))
+    write.csv(dataset$incurred_dataset, paste0(directory, "incurred_", i, "_cov.csv"))
+    write.csv(dataset$covariates_data$data, paste0(directory, "covariates_", i, "_cov.csv"))
   }
 }


### PR DESCRIPTION
This is a very minor pull request related to the supplied "datasets" directory in the package and their generation.
Running "generate_datasets.R" currently crashes when the "complexity_1", ..., "complexity_5" directories are not already created in the current directory, so the first edit creates these directories if they don't already exist.
The final edit is to make export the covariate data into csv files alongside the other outputs.

I would rerun the code and then add the generated covariate data in this pull request, except the "generate_datasets.R" does not create consistent outputs between different computers.
I ran this script on Windows, Linux, and Mac (both x86 and arm), and sometimes the generated datasets are the same, but most of the time they are significantly different.
So if you agree with these changes, can I please ask that you also add the generated covariates data to the datasets/complexity_* folders in another commit?

Thanks very much! Patrick